### PR TITLE
Added more net exceptions to those handled by Request#send

### DIFF
--- a/lib/postageapp/request.rb
+++ b/lib/postageapp/request.rb
@@ -8,7 +8,26 @@ class PostageApp::Request
     'Accept' => 'text/json, application/json'
   }
 
-  TimeoutError = defined?(::Timeout) ? ::Timeout::Error : ::TimeoutError
+  NET_HTTP_EXCEPTIONS = [
+    defined?(::Timeout) ? ::Timeout::Error : ::TimeoutError,
+    Errno::ECONNABORTED,
+    Errno::ECONNREFUSED,
+    Errno::ECONNRESET,
+    Errno::EHOSTUNREACH,
+    Errno::EINVAL,
+    Errno::ENETUNREACH,
+    Errno::EPIPE,
+    IOError,
+    Net::HTTPBadResponse,
+    Net::HTTPHeaderSyntaxError,
+    Net::ProtocolError,
+    SocketError,
+    Zlib::GzipFile::Error,
+  ]
+
+  NET_HTTP_EXCEPTIONS << OpenSSL::SSL::SSLError if defined?(OpenSSL)
+  NET_HTTP_EXCEPTIONS << Net::OpenTimeout if defined?(Net::OpenTimeout)
+
 
   # == Properties ===========================================================
   
@@ -65,7 +84,7 @@ class PostageApp::Request
           )
         )
 
-      rescue TimeoutError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::EPIPE => e
+      rescue *NET_HTTP_EXCEPTIONS => e
         e
       end
     

--- a/test/failed_request_test.rb
+++ b/test/failed_request_test.rb
@@ -106,9 +106,7 @@ class FailedRequestTest < MiniTest::Test
   end
 
   def test_resent_all_timeout
-    errors = [TimeoutError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH]
-
-    errors.each do |error|
+    PostageApp::Request::NET_HTTP_EXCEPTIONS.each do |error|
       mock_errored_send(error)
 
       request = PostageApp::Request.new(:send_message, {


### PR DESCRIPTION
This list now includes OpenSSL::SSL::SSLError, which was raised when the
PostageApp servers had an SSL error around 2019-09-09 02:37 am.

This lits now also includes other potential net exceptions as suggested by
the Ruby Faraday project:

https://salsa.debian.org/ruby-team/ruby-faraday/blob/12b91f51e2f51968f5654038da396cb837b408d7/lib/faraday/adapter/net_http.rb#L12