### PR TITLE
Rescue errors in FailedRequest:

### DIFF
--- a/lib/postageapp/request.rb
+++ b/lib/postageapp/request.rb
@@ -96,7 +96,11 @@ class PostageApp::Request
       if (response.retryable?)
         PostageApp::FailedRequest.store(self)
       elsif (response.ok?)
-        PostageApp::FailedRequest.resend_all
+        begin
+          PostageApp::FailedRequest.resend_all
+        rescue StandardError => e
+          PostageApp.logger.error("FailedRequest.resend_all failed: #{e}")
+        end
       end
     end
     


### PR DESCRIPTION
- delete file if FailedRequest.store encounters an error
- skip over resending request of marshal load failed
- verify that marshal loaded object is a request
- log errors from marshal load
- rescue errors when calling FailedRequest.resend_all from Request